### PR TITLE
Fix typos in REST API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Inspired by [@iros](https://github.com/iros)'s [documentation
 gist](https://gist.github.com/iros/3426278).
 
-Focus on using the templating Markdown to create comprehensive, structured and
-helpful API documentation. Structure should be regular and repeated across
+Focus on using templated Markdown to create comprehensive, structured and
+helpful API documentation. The structure should be consistent across
 endpoints and between projects.
 
 ## By example
@@ -14,7 +14,7 @@ endpoints and between projects.
 All templates are provided by example:
 
 * [Examples](examples) - For each template, a completed anonymised example.
-Where possible this example comes from a real project.
+Where possible these examples come from real projects.
 
 ## Free
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,11 @@
 # RESTAPIDocs Examples
 
-These examples were taken from projects mainly using [Django Rest
+These examples were taken from projects mainly using [Django REST
 Framework](https://github.com/tomchristie/django-rest-framework) and so the
-JSON responses are often similar to the way in which DRF makes responses.
+JSON responses are often similar to the way in which DRF formats responses.
 
-Where full URLs are provided in responses they will be rendered as if service
-is running on 'http://testserver/'.
+Where full URLs are provided in responses they will be rendered as if the
+service is running on 'http://testserver/'.
 
 ## Open Endpoints
 

--- a/examples/accounts/get.md
+++ b/examples/accounts/get.md
@@ -19,7 +19,7 @@ Includes their own Account if they have one.
 
 **Code** : `200 OK`
 
-**Content** : `{[]}`
+**Content** : `[]`
 
 ### OR
 

--- a/examples/accounts/pk/put.md
+++ b/examples/accounts/pk/put.md
@@ -68,7 +68,7 @@ posted to `/api/accounts/123/`...
 Endpoint will ignore irrelevant and read-only data such as parameters that
 don't exist, or `id` and `enterprise` fields which are not editable.
 
-E.g. if Account already exits:
+E.g. if Account already exists:
 
 **Data example**
 

--- a/examples/accounts/post.md
+++ b/examples/accounts/post.md
@@ -57,7 +57,7 @@ Provide name of Account to be created.
 
 ### Or
 
-**Condition** : If fields are missed.
+**Condition** : If required fields are missing.
 
 **Code** : `400 BAD REQUEST`
 

--- a/examples/user/put.md
+++ b/examples/user/put.md
@@ -87,7 +87,7 @@ User with `id` of '1234' sets their name, passing `UAPP` header of 'ios1_2':
 ```json
 {
     "first_name": [
-        "Please provide maximum 30 character or empty string",
+        "Please provide a maximum of 30 characters or an empty string",
     ]
 }
 ```


### PR DESCRIPTION
## Summary
- improve wording in README
- refine wording and fix typos in example documentation

## Testing
- `markdownlint -V` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684199cb3e0083269c35529c2a917b31